### PR TITLE
Add proxy support for jenkins servers without direct access to the internet

### DIFF
--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/global.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/global.jelly
@@ -15,7 +15,7 @@
 	  <f:entry title="Proxy Host" name="codedeploy" help="/plugin/codedeploy/help-proxyHost.html">
         <f:textbox default="" field="proxyHost" />
       </f:entry>
-      <f:entry title="AWS Secret Key" name="codedeploy" help="/plugin/codedeploy/help-proxyPort.html">
+      <f:entry title="Proxy Port" name="codedeploy" help="/plugin/codedeploy/help-proxyPort.html">
         <f:textbox default="" field="proxyPort" />
       </f:entry>
   </f:section>


### PR DESCRIPTION
We have our jenkins systems behind proxy servers internally which caused an issue for us.  I am not terribly familiar with the jenkins plugin process, but was able to compile this and get it to work.  

If this is useful, feel free to use it as necessary.  If nothing else, please add "proxy support" to your list of things to add.