### PR TITLE
Add the posibility of zipping a specific subfolder from the workspace

### DIFF
--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -17,6 +17,9 @@
   <f:entry title="S3 Prefix" field="s3prefix">
     <f:textbox default="/" />
   </f:entry>
+  <f:entry title="Subdirectory" field="subdirectory">
+    <f:textbox default="" />
+  </f:entry>
   <f:entry title="Include Files" field="includes">
     <f:textbox default="**" />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-subdirectory.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-subdirectory.html
@@ -1,0 +1,5 @@
+<div>
+    A subdirectory inside the workspace to be packed instead of the whole workspace. Remember that the
+    <i>appspec.yml</i> must be placed at the top of the .zip archive. The <i>excludes</i> and <i>includes</i> will
+    be applied based on this path.
+</div>


### PR DESCRIPTION
Hi,

I added a new configuration option that allows users to specify a subfolder to zip instead of the whole workspace. Usually there's a lot clutter in the workspace and only a designated *build* folder should be packed and uploaded to S3. The *appspec.yml* file and attached *.sh* scripts must be copied in the subfolder ahead of time.

Cosmin