### PR TITLE
Add the posibility of zipping a specific subdirectory from the workspace

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -304,11 +304,11 @@ public class AWSCodeDeployPublisher extends Publisher {
             s3Location.setBundleType(BundleType.Zip);
             s3Location.setETag(s3result.getETag());
 
-       	    RevisionLocation revisionLocation = new RevisionLocation();
-       	    revisionLocation.setRevisionType(RevisionLocationType.S3);
-       	    revisionLocation.setS3Location(s3Location);
+            RevisionLocation revisionLocation = new RevisionLocation();
+            revisionLocation.setRevisionType(RevisionLocationType.S3);
+            revisionLocation.setS3Location(s3Location);
 
-       	    return revisionLocation;
+            return revisionLocation;
         } finally {
             zipFile.delete();
         }

--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -276,8 +276,8 @@ public class AWSCodeDeployPublisher extends Publisher {
         String key;
 
         try {
+            this.logger.println("Zipping files into " + zipFile.getAbsolutePath());
 
-            this.logger.println("Zipping workspace into " + zipFile.getAbsolutePath());
             sourceDirectory.zip(
                     new FileOutputStream(zipFile),
                     new DirScanner.Glob(this.includes, this.excludes)

--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -76,7 +76,7 @@ public class AWSCodeDeployPublisher extends Publisher {
     public static final long      DEFAULT_TIMEOUT_SECONDS           = 900;
     public static final long      DEFAULT_POLLING_FREQUENCY_SECONDS = 15;
     public static final String    ROLE_SESSION_NAME                 = "jenkins-codedeploy-plugin";
-    public static final Regions[] AVAILABLE_REGIONS                 = {Regions.US_EAST_1, Regions.US_WEST_2};
+    public static final Regions[] AVAILABLE_REGIONS                 = {Regions.AP_SOUTHEAST_2, Regions.EU_WEST_1, Regions.US_EAST_1, Regions.US_WEST_2};
 
     private final String  s3bucket;
     private final String  s3prefix;

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -17,6 +17,9 @@
   <f:entry title="S3 Prefix" field="s3prefix">
     <f:textbox default="/" />
   </f:entry>
+  <f:entry title="Subdirectory" field="subdirectory">
+    <f:textbox default="" />
+  </f:entry>
   <f:entry title="Include Files" field="includes">
     <f:textbox default="**" />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -15,7 +15,7 @@
     <f:textbox />
   </f:entry>
   <f:entry title="S3 Prefix" field="s3prefix">
-    <f:textbox default="/" />
+    <f:textbox default="" />
   </f:entry>
   <f:entry title="Subdirectory" field="subdirectory">
     <f:textbox default="" />

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-subdirectory.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-subdirectory.html
@@ -1,0 +1,5 @@
+<div>
+    A subdirectory inside the workspace to be packed instead of the whole workspace. Remember that the
+    <i>appspec.yml</i> must be placed at the top of the .zip archive. The <i>excludes</i> and <i>includes</i> will
+    be applied based on this path.
+</div>


### PR DESCRIPTION
Hi,

I added a new configuration option that allows users to specify a subdirectory to zip instead of the whole workspace. Usually there's a lot clutter in the workspace and only a designated build folder should be packed and uploaded to S3. The appspec.yml file and attached .sh scripts must be copied in the subfolder ahead of time. I had a similar pull request earlier (closed it because it wasn't on a branch).

Cosmin