### PR TITLE
Remove the default slash from the S3 Prefix

### DIFF
--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -15,7 +15,7 @@
     <f:textbox />
   </f:entry>
   <f:entry title="S3 Prefix" field="s3prefix">
-    <f:textbox default="/" />
+    <f:textbox default="" />
   </f:entry>
   <f:entry title="Include Files" field="includes">
     <f:textbox default="**" />


### PR DESCRIPTION
Hi,

The default **/** for the *S3 Prefix* setting is deceiving. If the user will use the **/** as its first character (as it is the tendency) S3 will create a "blank" folder, since directories in S3 are just an abstraction around the **/** character.

![jenkins](https://cloud.githubusercontent.com/assets/525590/7759682/d74b5330-0013-11e5-96e0-d5890ea89e2b.png)

Cosmin

 