### PR TITLE
Enable the use of environment variables in Application Group Name

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -81,7 +81,7 @@ public class AWSCodeDeployPublisher extends Publisher {
     private final String  s3bucket;
     private final String  s3prefix;
     private final String  applicationName;
-    private final String  deploymentGroupName; // TODO allow for deployment to multiple groups
+    private       String  deploymentGroupName; // TODO allow for deployment to multiple groups
     private final String  deploymentConfig;
     private final Long    pollingTimeoutSec;
     private final Long    pollingFreqSec;
@@ -209,10 +209,13 @@ public class AWSCodeDeployPublisher extends Publisher {
 
         try {
 
+            Map<String, String> envVars = build.getEnvironment(listener);
+            this.deploymentGroupName = Util.replaceMacro(this.deploymentGroupName, envVars);
+
             verifyCodeDeployApplication(aws);
 
             String projectName = build.getProject().getName();
-            RevisionLocation revisionLocation = zipAndUpload(aws, projectName, getSourceDirectory(build.getWorkspace()), build.getEnvironment(listener));
+            RevisionLocation revisionLocation = zipAndUpload(aws, projectName, getSourceDirectory(build.getWorkspace()), envVars);
 
             registerRevision(aws, revisionLocation);
             String deploymentId = createDeployment(aws, revisionLocation);

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-applicationName.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-applicationName.html
@@ -2,5 +2,6 @@
   The name of the AWS CodeDeploy application you wish to deploy to. This plugin assumes that you've
   already created the application and deployment group. If you haven't already, work through the <a
   href="http://alpha-docs-aws.amazon.com/codedeploy/latest/userguide/how-to-create-application.html">How
-  to create an Application with AWS CodeDeploy</a> documentation.
+  to create an Application with AWS CodeDeploy</a> documentation. You can use environment variables
+  in this field.
 </div>


### PR DESCRIPTION
This commit can resolve issue #24.

I'm not a Java programmer and I'm sure there's better ways to code this. I've tried the plugin with this changes in my environment and it worked as expected.

Feel free to modify or reject if you think the code is not good enough.