### PR TITLE
AWS CodeDeploy Deployment Group environment variable value ovewrites field value

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -82,7 +82,7 @@ public class AWSCodeDeployPublisher extends Publisher {
     private final String  s3bucket;
     private final String  s3prefix;
     private final String  applicationName;
-    private       String  deploymentGroupName; // TODO allow for deployment to multiple groups
+    private final String  deploymentGroupName; // TODO allow for deployment to multiple groups
     private final String  deploymentConfig;
     private final Long    pollingTimeoutSec;
     private final Long    pollingFreqSec;
@@ -214,15 +214,15 @@ public class AWSCodeDeployPublisher extends Publisher {
         try {
 
             Map<String, String> envVars = build.getEnvironment(listener);
-            this.deploymentGroupName = Util.replaceMacro(this.deploymentGroupName, envVars);
+            String deploymentGroupName = Util.replaceMacro(this.deploymentGroupName, envVars);
 
-            verifyCodeDeployApplication(aws);
+            verifyCodeDeployApplication(aws, deploymentGroupName);
 
             String projectName = build.getProject().getName();
-            RevisionLocation revisionLocation = zipAndUpload(aws, projectName, getSourceDirectory(build.getWorkspace()), envVars);
+            RevisionLocation revisionLocation = zipAndUpload(aws, projectName, getSourceDirectory(build.getWorkspace()), envVars, deploymentGroupName);
 
             registerRevision(aws, revisionLocation);
-            String deploymentId = createDeployment(aws, revisionLocation);
+            String deploymentId = createDeployment(aws, revisionLocation, deploymentGroupName);
 
             success = waitForDeployment(aws, deploymentId);
 
@@ -262,7 +262,7 @@ public class AWSCodeDeployPublisher extends Publisher {
         return false;
     }
 
-    private void verifyCodeDeployApplication(AWSClients aws) throws IllegalArgumentException {
+    private void verifyCodeDeployApplication(AWSClients aws, String deploymentGroupName) throws IllegalArgumentException {
         // Check that the application exists
         ListApplicationsResult applications = aws.codedeploy.listApplications();
 
@@ -276,12 +276,12 @@ public class AWSCodeDeployPublisher extends Publisher {
                         .withApplicationName(this.applicationName)
         );
 
-        if (!deploymentGroups.getDeploymentGroups().contains(this.deploymentGroupName)) {
-            throw new IllegalArgumentException("Cannot find deployment group named '" + this.deploymentGroupName + "'");
+        if (!deploymentGroups.getDeploymentGroups().contains(deploymentGroupName)) {
+            throw new IllegalArgumentException("Cannot find deployment group named '" + deploymentGroupName + "'");
         }
     }
 
-    private RevisionLocation zipAndUpload(AWSClients aws, String projectName, FilePath sourceDirectory, Map<String, String> envVars) throws IOException, InterruptedException, IllegalArgumentException {
+    private RevisionLocation zipAndUpload(AWSClients aws, String projectName, FilePath sourceDirectory, Map<String, String> envVars, String deploymentGroupName) throws IOException, InterruptedException, IllegalArgumentException {
 
         File zipFile = File.createTempFile(projectName + "-", ".zip");
         String key;
@@ -289,14 +289,14 @@ public class AWSCodeDeployPublisher extends Publisher {
         File dest;
         try {
             if (this.deploymentGroupAppspec) {
-                appspec = new File(sourceDirectory + "/appspec." + this.deploymentGroupName + ".yml");
+                appspec = new File(sourceDirectory + "/appspec." + deploymentGroupName + ".yml");
                 if (appspec.exists()) {
                     dest = new File(sourceDirectory + "/appspec.yml");
                     FileUtils.copyFile(appspec, dest);
-                    logger.println("Use appspec." + this.deploymentGroupName + ".yml");
+                    logger.println("Use appspec." + deploymentGroupName + ".yml");
                 }
                 if (!appspec.exists()) {
-                    throw new IllegalArgumentException("/appspec." + this.deploymentGroupName + ".yml file does not exist" );
+                    throw new IllegalArgumentException("/appspec." + deploymentGroupName + ".yml file does not exist" );
                 }
 
             }
@@ -352,14 +352,14 @@ public class AWSCodeDeployPublisher extends Publisher {
         );
     }
 
-    private String createDeployment(AWSClients aws, RevisionLocation revisionLocation) throws Exception {
+    private String createDeployment(AWSClients aws, RevisionLocation revisionLocation, String deploymentGroupName) throws Exception {
 
         this.logger.println("Creating deployment with revision at " + revisionLocation);
 
         CreateDeploymentResult createDeploymentResult = aws.codedeploy.createDeployment(
                 new CreateDeploymentRequest()
                         .withDeploymentConfigName(this.deploymentConfig)
-                        .withDeploymentGroupName(this.deploymentGroupName)
+                        .withDeploymentGroupName(deploymentGroupName)
                         .withApplicationName(this.applicationName)
                         .withRevision(revisionLocation)
                         .withDescription("Deployment created by Jenkins")


### PR DESCRIPTION
This pull request should hopefully fix the following issue I've walked through in "Steps to reproduce" below. I have it currently running on my personal Jenkins and it seems to have fixed the issue. Probably not the cleanest and unsure how to standardize this pull request, so I've just listed a steps to reproduce below and I'd be happy to make any code changes as necessary.

## Steps to reproduce
* Install v1.8 of AWS Codedeploy plugin on Jenkins 1.583
* Create a project and make sure to select "This build is parameterized"
* Add "Deploy an application to AWS CodeDeploy" as a Post-Build step to a project
* In the "AWS CodeDeploy Deployment Group" field, use a parameter of the project (in this example, I will use $DEPLOYMENT_GROUP to represent the parameter). So the value of the "AWS CodeDeploy Deployment Group" field is $DEPLOYMENT_GROUP
* Run a build, pass "QA" as the value of the parameter $DEPLOYMENT_GROUP
* Wait until the build is complete complete, then revisit (leave the "Configure" page and visit it again) the "Configure" page of the project you created.
* The value of the "AWS CodeDeploy Deployment Group" field is now "QA"