### PR TITLE
added S3 Bucket restriction

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -289,6 +289,10 @@ public class AWSCodeDeployPublisher extends Publisher {
         String prefix = getS3PrefixFromEnv();
         String bucket = getS3BucketFromEnv();
 
+        if(bucket.indexOf("/") > 0){
+            throw new IllegalArgumentException("S3 Bucket field cannot contain any subdirectories.  Bucket name only!");
+        }
+
         try {
             if (this.deploymentGroupAppspec) {
                 appspec = new File(sourceDirectory + "/appspec." + deploymentGroupName + ".yml");


### PR DESCRIPTION
This assures that your S3 path is properly constructed.
Should help avoid confusion when your s3 file won't deploy because of a checksum error.  