### PR TITLE
Skip codedeploy if build was not mark as success

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -185,9 +185,9 @@ public class AWSCodeDeployPublisher extends Publisher {
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         this.logger = listener.getLogger();
         envVars = build.getEnvironment(listener);
-        final boolean buildFailed = build.getResult() == Result.FAILURE;
-        if (buildFailed) {
-            logger.println("Skipping CodeDeploy publisher as build failed");
+        final boolean buildSucceed = build.getResult() == Result.SUCCESS;
+        if (!buildSucceed) {
+            logger.println("Skipping CodeDeploy publisher as build was not successful");
             return true;
         }
 


### PR DESCRIPTION
Before we run codedeploy if build was not mark as failure.
This meant that we deployed for ABORTED, NOT_BUILT and UNSTABLE states as well
(http://javadoc.jenkins-ci.org/hudson/model/Result.html)
Until there is a finer grained configuration option, it's safer to deploy for
SUCCESS builds only.

Fixes #61