### PR TITLE
Add Github deploy

### DIFF
--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -18,6 +18,12 @@
   <f:entry title="S3 Prefix" field="s3prefix">
     <f:textbox default="" />
   </f:entry>
+  <f:entry title="GitHub Repository" field="githubRespository">
+    <f:textbox default="" />
+  </f:entry>
+  <f:entry title="GitHub Commit Id" field="githubCommitId">
+    <f:textbox default="" />
+  </f:entry>
   <f:entry title="Subdirectory" field="subdirectory">
     <f:textbox default="" />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-githubCommitId.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-githubCommitId.html
@@ -1,0 +1,3 @@
+<div>
+  The GitHub commit id hash of the revision to be pushed to CodeDeploy. This is to be used in Pipeline mode.
+</div>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-githubRepository.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-githubRepository.html
@@ -1,0 +1,3 @@
+<div>
+  The GitHub repository used to pull the revision from. This is to be used in Pipeline mode.
+</div>


### PR DESCRIPTION
I'm submitting this PR under the Apache 2.0 License.
I have built this plugin and deployed it to our Jenkins server and it's working as expected using Github deployments in Pipeline mode.

E.g.
```
stage('Deploy') {
      steps {
        input "Deploy?"
        
        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'AWSCreds',
                        accessKeyVariable: 'awsAccessKey', secretKeyVariable: 'awsSecretKey']]) {
    
          step([$class: 'AWSCodeDeployPublisher',
            applicationName: 'site.com',
            awsAccessKey: env.awsAccessKey,
            awsSecretKey: env.awsSecretKey,
            credentials: 'awsAccessKey',
            deploymentGroupAppspec: false,
            deploymentGroupName: 'Production-site.com',
            deploymentConfig: 'CodeDeployDefault.OneAtATime',
            deploymentMethod: 'deploy',
            includes: '**',
            region: 'us-east-1',
            githubRepository: 'example/site',
            githubCommitId: env.GIT_COMMIT,
            waitForCompletion: true])
        }
      }
    }
```