### PR TITLE
Bump AWS SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.119</version>
+      <version>1.11.248</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Minor change to bump AWS SDK. The version in `pom.xml` was a very old one and caused problems when trying to use some methods added since then.