### PR TITLE
Add configuration parameter Zip Name Prefix

### DIFF
--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -39,7 +39,7 @@
   <f:entry title="Proxy Port" field="proxyPort">
     <f:textbox default="" />
   </f:entry>
-  <f:entry title="Zip name prefix" field="zipNamePrefix">
+  <f:entry title="Zip Name Prefix" field="zipNamePrefix">
     <f:textbox />
   </f:entry>
   <f:entry title="Version File" field="versionFileName">

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -39,6 +39,9 @@
   <f:entry title="Proxy Port" field="proxyPort">
     <f:textbox default="" />
   </f:entry>
+  <f:entry title="Zip name prefix" field="zipNamePrefix">
+    <f:textbox />
+  </f:entry>
   <f:entry title="Version File" field="versionFileName">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-versionFileName.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-versionFileName.html
@@ -1,0 +1,11 @@
+<div>
+  The path to a version file name relative to the subdirectory. The file must contain a version of the application.
+  If Version file name is set the name of the zip uploaded to S3 will be :
+  build display name + "-" + version.zip
+  Or
+  Zip prefix name + "-" + version.zip
+  If not set, the name will be
+  build display name + "-" + generated uid.zip
+  Or
+  Zip prefix name + "-" + generated uid.zip
+</div>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
@@ -1,3 +1,3 @@
 <div>
-  The prefix of the name of the zip you wish to deploy to S3. If none is set it will use the display name of the build (ex: #3).
+  The prefix of the name of the zip you wish to deploy to S3. If none is set the display name of the build (ex: #3) will be use.
 </div>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
@@ -1,0 +1,4 @@
+<div>
+  The prefix of the name of the zip you wish to deploy to S3. If none is set it will use the display name of the build.
+  This is usually the build number. Ex: #3
+</div>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-zipNamePrefix.html
@@ -1,4 +1,3 @@
 <div>
-  The prefix of the name of the zip you wish to deploy to S3. If none is set it will use the display name of the build.
-  This is usually the build number. Ex: #3
+  The prefix of the name of the zip you wish to deploy to S3. If none is set it will use the display name of the build (ex: #3).
 </div>


### PR DESCRIPTION
Add a parameter : Zip Name Prefix that replace build.getDisplayName() if set.
Add contextual help to Zip Name Prefix.
Add contextual help to Version File Name
Correct tmp dir for Jenkins on Windows.