### PR TITLE
Allow customisation of deployment description

### DIFF
--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -90,6 +90,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
     private final String  applicationName;
     private final String  deploymentGroupName; // TODO allow for deployment to multiple groups
     private final String  deploymentConfig;
+    private final String  deploymentDescription;
     private final Long    pollingTimeoutSec;
     private final Long    pollingFreqSec;
     private final boolean deploymentGroupAppspec;
@@ -121,6 +122,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
             String applicationName,
             String deploymentGroupName,
             String deploymentConfig,
+            String deploymentDescription,
             String region,
             Boolean deploymentGroupAppspec,
             Boolean waitForCompletion,
@@ -147,6 +149,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
         } else {
             this.deploymentConfig = deploymentConfig;
         }
+        this.deploymentDescription = deploymentDescription;
         this.region = region;
         this.includes = includes;
         this.excludes = excludes;
@@ -445,7 +448,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
                         .withDeploymentGroupName(getDeploymentGroupNameFromEnv())
                         .withApplicationName(getApplicationNameFromEnv())
                         .withRevision(revisionLocation)
-                        .withDescription("Deployment created by Jenkins")
+                        .withDescription(getDeploymentDescriptionFromEnv())
         );
 
         return createDeploymentResult.getDeploymentId();
@@ -677,6 +680,10 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
         return deploymentConfig;
     }
 
+    public String getDeploymentDescription() {
+        return deploymentDescription;
+    }
+
     public String getS3bucket() {
         return s3bucket;
     }
@@ -763,6 +770,10 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
 
     public String getDeploymentConfigFromEnv() {
         return Util.replaceMacro(this.deploymentConfig, envVars);
+    }
+
+    public String getDeploymentDescriptionFromEnv() {
+        return Util.replaceMacro(this.deploymentDescription, envVars);
     }
 
     public String getS3BucketFromEnv() {

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/config.jelly
@@ -9,6 +9,9 @@
   <f:entry title="AWS CodeDeploy Deployment Config" field="deploymentConfig">
     <f:textbox />
   </f:entry>
+  <f:entry title="AWS CodeDeploy Deployment Description" field="deploymentDescription">
+    <f:textbox />
+  </f:entry>
   <f:entry title="AWS Region" field="region">
     <f:select />
   </f:entry>

--- a/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-deploymentDescription.html
+++ b/src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/help-deploymentDescription.html
@@ -1,0 +1,5 @@
+<div>
+  An optional description message to add when creating an AWS CodeDeploy deployment. The
+  description for a deployment can be found by calling <code>codedeploy:GetDeployment</code>.
+  You can use environment variables in this field.
+</div>


### PR DESCRIPTION
Hi! Thanks for providing a great plugin. I have been using it for a couple of years now while working at a few different companies.

I think it would be more useful to be able to put something like $BUILD_URL in the deployment description field rather than "Deployment created by Jenkins". I would then be able to lookup the Jenkins build for a given deployment like so:

```
$ aws deploy get-deployment --deployment-id d-123456
{
    "deploymentInfo": {
        ...
        "description": "https://jenkins.example.com/job/example-build/17",
        ...
    }
}
```