### PR TITLE
Fix cross-account deploys restricted by externalId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
@@ -61,7 +61,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -523,7 +523,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
      * Descriptor for {@link AWSCodeDeployPublisher}. Used as a singleton.
      * The class is marked as public so that it can be accessed from views.
      *
-     * See <tt>src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/*.jelly</tt>
+     * See <code>src/main/resources/com/amazonaws/codedeploy/AWSCodeDeployPublisher/*.jelly</code>
      * for the actual HTML fragment for the configuration screen.
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.

--- a/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
+++ b/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java
@@ -219,7 +219,7 @@ public class AWSCodeDeployPublisher extends Publisher implements SimpleBuildStep
             aws = AWSClients.fromIAMRole(
                 this.region,
                 this.iamRoleArn,
-                this.getDescriptor().getExternalId(),
+                this.externalId,
                 this.proxyHost,
                 this.proxyPort);
         }


### PR DESCRIPTION
## Issue

It's possible to [restrict cross-account deploys](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) to a specific `externalId` in IAM role policies.

Up until the present fix, however, such deploys with a custom `externalId` fail with HTTP 403 forbidden; removing the restriction from the IAM policy instantly allows for the deploy to happen.

My understanding of what's happening is:
1. a new `AWSCodeDeployPublisher` instance receives the `externalId` through its constructor and saves it:
https://github.com/awslabs/aws-codedeploy-plugin/blob/40d7b24c95edef27f2879037ae1add30fc3f3831/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java#L108-L130
2. when using `"iamRoleArn"` as credentials, the instance will retrieve `externalId` from the descriptor:
https://github.com/awslabs/aws-codedeploy-plugin/blob/40d7b24c95edef27f2879037ae1add30fc3f3831/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java#L204-L207
3. but the descriptor instance initializes its own `externalId` randomly:
https://github.com/awslabs/aws-codedeploy-plugin/blob/40d7b24c95edef27f2879037ae1add30fc3f3831/src/main/java/com/amazonaws/codedeploy/AWSCodeDeployPublisher.java#L460-L464

## Description of changes

Functional:
* use `AWSCodeDeployPublisher.externalId` instead of the descriptor's

Tooling-related:
* support building with recent versions of maven (HTTPS-less HTTP mirrors are now blocked)[*]
* fix Javadoc generation in Java 17 (it broke the build)

[*] closes #107, #115 and #116

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
